### PR TITLE
fix: Fix issue #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ changes will be documented in this file.
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Fixed appendix numbering. Appendices now always start at `A` and increment
+  alphabetically.
+
 ## [0.2.2] - 2025-08-31
 
 ### Fixed

--- a/lib.typ
+++ b/lib.typ
@@ -242,7 +242,7 @@
   if appendices != none and appendices != [] {
     heading("Appendices", numbering: none)
     // Given that the appendices heading has no numbering, the following
-    // appendices will inherit the subsection counter form the previous section.
+    // appendices will inherit the subsection counter from the previous section.
     counter(heading).update(0)
 
     set heading(

--- a/lib.typ
+++ b/lib.typ
@@ -241,6 +241,9 @@
 
   if appendices != none and appendices != [] {
     heading("Appendices", numbering: none)
+    // Given that the appendices heading has no numbering, the following
+    // appendices will inherit the subsection counter form the previous section.
+    counter(heading).update(0)
 
     set heading(
       // Allow users to write each appendix as a level 1 heading, but then treat


### PR DESCRIPTION
The `Appendices` section, being `numbering: none` was inheriting the subsection counter from the previous numbered section. This caused appendices to not always start at `A` (depending on how many subsections the last section had). 